### PR TITLE
Syncing zertodocker with separate sleepy-puppy-docker repo

### DIFF
--- a/sleepy-puppy/README.md
+++ b/sleepy-puppy/README.md
@@ -8,15 +8,36 @@ This repo utilizes docker compose to launch a cluster of containers to support t
 
 ----------
 
+###Requirements
+* Latest version of [Docker Toolbox](https://www.docker.com/toolbox)
+* A vm you have created with docker-machine
+* Terminal with all docker env variables set
 
 Starting
 -------------
+First determine the ip address of your docker vm
+
+> docker-machine ls
+
+Replace the host variable in `docker-compose.yaml` with that IP
+
+```
+    host: <YOUR IP ADDRESS HERE>
+```
+
+Start the conatiners
 
 > docker-compose up
 
 Stopping
 -------------
 > docker-compose stop
+
+Try It Out
+-------------
+Launch web browser and connect to your docker container's IP over http. 
+The default credientials are `admin/password`
+
 
 Architecture
 -------------
@@ -60,5 +81,3 @@ For production use, you will want to modify these values.
 The username for the postgres database is `postgres`.  The password for this database is actually set in the api-start.sh file found within the sleepy-puppy-web container.  This password is set to `password`.
 
 You may wish to change this password for production use.
-
-

--- a/sleepy-puppy/docker-compose.yml
+++ b/sleepy-puppy/docker-compose.yml
@@ -13,7 +13,7 @@ sleepy-puppy-web:
     secret_key: 5(15ds+i2+%ik6z&!yer+ga9m=e%jcqiz_5wszg)r-z!2--b2d
     csrf_session_key: 5(18ds+i2+%ik6z&!yer+ga9m=e%jcqiz_5wszg)r-z!2--b2d
     DOCKER_ADMIN_PASS: password
-
+    host: 192.168.59.103
 sleepy-puppy-nginx:
   restart: always
   build: ./nginx/

--- a/sleepy-puppy/nginx/sites-enabled/sleepy_puppy
+++ b/sleepy-puppy/nginx/sites-enabled/sleepy_puppy
@@ -4,10 +4,6 @@ server {
     server_name sleepypuppy.io;
     charset utf-8;
 
-    location /static {
-        alias /usr/local/src/sleepy-puppy/sleepypuppy/static;
-        autoindex on;
-    }
 
     location / {
         proxy_pass http://web:8000;

--- a/sleepy-puppy/web/Dockerfile
+++ b/sleepy-puppy/web/Dockerfile
@@ -18,7 +18,7 @@ MAINTAINER Netflix Open Source Development <talent@netflix.com>
 RUN apt-get update && apt-get -y -q install python-software-properties software-properties-common postgresql-9.3 postgresql-client-9.3 postgresql-contrib-9.3 && apt-get install -y curl python-dev python-pip git sudo && apt-get -y -q install python-psycopg2 libpq-dev libffi-dev
 
 RUN cd /usr/local/src &&\
-  git clone --branch develop https://github.com/sbehrens/sleepy-puppy.git &&\
+  git clone --depth 1 -b 0.2.2b --branch master https://github.com/Netflix/sleepy-puppy.git &&\
   cd sleepy-puppy &&\
   python setup.py install
 


### PR DESCRIPTION
Updating zerotodocker to work the same way the standalone sleepy-puppy-docker works.

https://github.com/Netflix/sleepy-puppy-docker